### PR TITLE
Potential fix for code scanning alert no. 34: Use of password hash with insufficient computational effort

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "lodash": "^4.17.21",
     "method-override": "^3.0.0",
     "mongoose": "^8.15.1",
-    "nodemailer": "^7.0.7"
+    "nodemailer": "^7.0.7",
+    "bcrypt": "^6.0.0"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/TheGuy3201/MyPortfolio/security/code-scanning/34](https://github.com/TheGuy3201/MyPortfolio/security/code-scanning/34)

The primary fix is to replace the password hashing method in `encryptPassword` with a computationally expensive function specifically designed for password storage, such as bcrypt. This requires using the `bcrypt` library, which must be imported. The salt can be generated by bcrypt itself during hashing, so manual `makeSalt` handling and storing `salt` in the schema are unnecessary (the resulting bcrypt hash contains its salt internally). 

Specific changes:
- Import `bcrypt` at the top of the file.
- Change the `encryptPassword` method to use `bcrypt.hashSync(password, saltRounds)` for hashing (where `saltRounds` is the computational cost, e.g., 10 or 12).
- The virtual setter for `password` should call bcrypt's salt generation and hash the password, storing the result in `hashed_password`.
- The `authenticate` method should verify the password using `bcrypt.compareSync(plainText, this.hashed_password)`.
- The `salt` field and `makeSalt` method can be removed since bcrypt handles salt management.
- Remove or adjust places that manually set or use `salt`.

All edits must be made in `server/models/users.model.js` within the context shown above.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
