### PR TITLE
Potential fix for code scanning alert no. 3: Missing rate limiting

### DIFF
--- a/server/routes/auth.routes.js
+++ b/server/routes/auth.routes.js
@@ -1,10 +1,18 @@
 import express from 'express'
 import authCtrl from '../controllers/auth.controller.js'
+import rateLimit from 'express-rate-limit'
+
+// Apply a strict rate limit to the /signin endpoint to prevent brute-force attacks
+const signinLimiter = rateLimit({
+  windowMs: 5 * 60 * 1000, // 5 minutes
+  max: 5, // limit each IP to 5 requests per windowMs
+  message: 'Too many login attempts from this IP, please try again after 5 minutes'
+})
 
 const router = express.Router()
 
 router.route('/signin')
-  .post(authCtrl.signin)
+  .post(signinLimiter, authCtrl.signin)
 
 router.route('/signout')
   .get(authCtrl.signout)


### PR DESCRIPTION
Potential fix for [https://github.com/TheGuy3201/MyPortfolio/security/code-scanning/3](https://github.com/TheGuy3201/MyPortfolio/security/code-scanning/3)

The best way to fix this problem is to add a rate limiting middleware to the `/signin` route in `server/routes/auth.routes.js`. The most widely adopted rate limiter for Express is `express-rate-limit`, which is actively maintained and offers robust features. You need to import it, configure a suitable policy (for authentication, a low burst rate is usually appropriate), and apply it specifically to the `/signin` route by adding the middleware as an argument before the route handler (`.post`). All necessary code changes are confined to `server/routes/auth.routes.js`.

You will need to:
- Import `express-rate-limit` at the top of the file.
- Define a rate limiting policy (e.g., 5 requests per 5 minutes per IP for `/signin`).
- Add the rate limiter as middleware to the `.post(authCtrl.signin)` route.
Do not apply rate limiting to the `/signout` route, as it is not a sensitive operation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
