### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/server/express.js
+++ b/server/express.js
@@ -12,12 +12,20 @@ import educationRoutes from './routes/educations.routes.js';
 import contactsRoutes from './routes/contacts.routes.js';
 import servicesRoutes from './routes/services.routes.js';
 import authRoutes from './routes/auth.routes.js'; // Import authRoutes
+import rateLimit from 'express-rate-limit';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const app = express();
 
+// Rate limiter middleware for catch-all route (serving index.html)
+const catchAllLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+  standardHeaders: true, // Return rate limit info in the RateLimit-* headers
+  legacyHeaders: false, // Disable the X-RateLimit-* headers
+});
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 app.use(bodyParser.json());
@@ -78,7 +86,7 @@ app.get('/robots.txt', (req, res) => {
 
 // Catch-all handler: send back React's index.html file for client-side routing
 // This MUST come last, after all API routes and error handling
-app.get('*', (req, res) => {
+app.get('*', catchAllLimiter, (req, res) => {
   res.sendFile(path.join(__dirname, '..', 'client', 'dist', 'index.html'));
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/TheGuy3201/MyPortfolio/security/code-scanning/2](https://github.com/TheGuy3201/MyPortfolio/security/code-scanning/2)

To fix the problem, we should introduce a rate-limiting middleware to cap the number of requests any client can make during a time window. The standard solution is to use the `express-rate-limit` package, as recommended in the CodeQL documentation. Specifically, we need to:

1. Import `express-rate-limit`.
2. Configure a rate limiter (for example, maximum 100 requests per 15 minutes).
3. Apply it *specifically* to the catch-all route for `app.get('*', ...)`, so that only requests hitting this fallback route are capped. (We could, alternatively, apply it globally if desired.)
4. The rest of the app remains unchanged.

All edits will be in `server/express.js`.  
We will also need to add the `express-rate-limit` package to project dependencies.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
