### PR TITLE
Potential fix for code scanning alert no. 26: Missing rate limiting

### DIFF
--- a/server/routes/contacts.routes.js
+++ b/server/routes/contacts.routes.js
@@ -1,9 +1,16 @@
 import express from 'express'
 import contactsCtrl from '../controllers/contacts.controller.js'
 import authCtrl from '../controllers/auth.controller.js'
+import rateLimit from 'express-rate-limit'
 
 const router = express.Router()
 
+// Rate limiter for destructive actions (e.g., DELETE)
+const deleteLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 10, // limit each IP to 10 delete requests per window
+    message: 'Too many delete requests from this IP, please try again later.'
+})
 router.route('/')
     .post(contactsCtrl.create)  // Anyone can create a contact
     .get(authCtrl.requireSignin, authCtrl.requireAdmin, contactsCtrl.list)  // Only admin can list contacts
@@ -11,7 +18,7 @@ router.route('/')
 router.route('/:contactId')
     .get(authCtrl.requireSignin, authCtrl.requireAdmin, contactsCtrl.read)
     .put(authCtrl.requireSignin, authCtrl.requireAdmin, contactsCtrl.update)
-    .delete(authCtrl.requireSignin, authCtrl.requireAdmin, contactsCtrl.remove)
+    .delete(authCtrl.requireSignin, authCtrl.requireAdmin, deleteLimiter, contactsCtrl.remove)
 
 router.param('contactId', contactsCtrl.contactByID)
 


### PR DESCRIPTION
Potential fix for [https://github.com/TheGuy3201/MyPortfolio/security/code-scanning/26](https://github.com/TheGuy3201/MyPortfolio/security/code-scanning/26)

To fix the problem, you should add rate-limiting middleware to the endpoints that perform database modifications, especially destructive operations like deletion. The best approach is to use a well-established middleware like `express-rate-limit`, applied (a) globally to all router endpoints, or (b) selectively to sensitive endpoints. Since we only see this router, and following the principle of least privilege, let's add a rate limiter specifically to the DELETE route (`DELETE /:contactId`). This requires importing `express-rate-limit`, defining a limiter instance (with reasonable defaults, e.g., 10 requests per 15 min for deletes), and injecting it into the DELETE route's middleware chain. This can be done entirely within the shown code.

Because this file uses ES module syntax (`import ... from ...`), proper import should be handled accordingly (using `import rateLimit from 'express-rate-limit'`). You will need to install the `express-rate-limit` dependency if it is not already present.

#### Steps:
- Add an import for `express-rate-limit` at the top.
- Define a `deleteLimiter` instance with reasonable settings above your router definition.
- Inject `deleteLimiter` into the `.delete` route middleware chain.
- No changes to existing protected functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
