### PR TITLE
Potential fix for code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/server/express.js
+++ b/server/express.js
@@ -14,6 +14,7 @@ import servicesRoutes from './routes/services.routes.js';
 import authRoutes from './routes/auth.routes.js'; // Import authRoutes
 import rateLimit from 'express-rate-limit';
 
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -78,8 +79,16 @@ app.use((err, req, res, next) => {
   }
 });
 
+
+// Rate limiter middleware for robots.txt route
+const robotsLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+  standardHeaders: true,
+  legacyHeaders: false,
+});
 // Serve robots.txt from client/public directory
-app.get('/robots.txt', (req, res) => {
+app.get('/robots.txt', robotsLimiter, (req, res) => {
   res.type('text/plain');
   res.sendFile(path.join(__dirname, '..', 'client', 'public', 'robots.txt'));
 });


### PR DESCRIPTION
Potential fix for [https://github.com/TheGuy3201/MyPortfolio/security/code-scanning/1](https://github.com/TheGuy3201/MyPortfolio/security/code-scanning/1)

To fix the flagged issue, we should apply rate limiting to the `/robots.txt` route handler. The best approach is to create a dedicated rate limiter instance (using `express-rate-limit`) for this specific route. We'll use reasonable defaults (e.g., 100 requests per 15 minutes per IP, matching the existing `catchAllLimiter`). We simply need to insert this middleware for the `/robots.txt` route in `server/express.js`, ensuring requests to this endpoint cannot be abused to perform excessive file system loads. No changes to the logic or file serving are required—just add the rate limiter as middleware for this route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
