### PR TITLE
Potential fix for code scanning alert no. 14: Missing rate limiting

### DIFF
--- a/server/routes/educations.routes.js
+++ b/server/routes/educations.routes.js
@@ -10,6 +10,13 @@ const createEducationLimiter = rateLimit({
   message: 'Too many education create requests from this IP, please try again after 15 minutes.'
 });
 
+// Limit to 5 delete requests per 15 minutes per IP (admins only)
+const deleteEducationLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 5,
+  message: 'Too many education delete requests from this IP, please try again after 15 minutes.'
+});
+
 const router = express.Router()
 
 router.route('/')
@@ -24,7 +31,12 @@ router.route('/')
 router.route('/:educationId')
   .get(educationCtrl.read)
   .put(authCtrl.requireSignin, authCtrl.requireAdmin, educationCtrl.update)
-  .delete(authCtrl.requireSignin, authCtrl.requireAdmin, educationCtrl.remove)
+  .delete(
+    deleteEducationLimiter,
+    authCtrl.requireSignin,
+    authCtrl.requireAdmin,
+    educationCtrl.remove
+  )
 
 router.param('educationId', educationCtrl.educationByID)
 


### PR DESCRIPTION
Potential fix for [https://github.com/TheGuy3201/MyPortfolio/security/code-scanning/14](https://github.com/TheGuy3201/MyPortfolio/security/code-scanning/14)

To fix the missing rate limiting on the delete education route, the best approach is to add a rate limiter middleware to the `.delete` handler, similar in style to the limiter used for the create route. This can be accomplished by defining a new rate limiter (e.g., `deleteEducationLimiter`) with appropriate limits for deletion requests—likely lower than create limits due to higher risk from mass deletions. The new limiter should be instantiated with a reasonable window and max count, then applied to the `.delete` endpoint as middleware ahead of the authentication and actual handler logic. All changes must remain within the file `server/routes/educations.routes.js`, as shown.

Steps:
- Define `deleteEducationLimiter` after `createEducationLimiter`.
- Apply `deleteEducationLimiter` to the `.delete` method in the `/educationId` route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
