### PR TITLE
Potential fix for code scanning alert no. 44: Missing rate limiting

### DIFF
--- a/server/routes/contacts.routes.js
+++ b/server/routes/contacts.routes.js
@@ -12,7 +12,7 @@ router.route('/')
 
 router.route('/:contactId')
   .get(readLimiter, authCtrl.requireSignin, authCtrl.requireAdmin, contactsCtrl.read)
-  .put(authCtrl.requireSignin, authCtrl.requireAdmin, adminLimiter, contactsCtrl.update)
+  .put(adminLimiter, authCtrl.requireSignin, authCtrl.requireAdmin, contactsCtrl.update)
   .delete(authCtrl.requireSignin, authCtrl.requireAdmin, deleteLimiter, contactsCtrl.remove)
 
 router.param('contactId', contactsCtrl.contactByID)


### PR DESCRIPTION
Potential fix for [https://github.com/TheGuy3201/MyPortfolio/security/code-scanning/44](https://github.com/TheGuy3201/MyPortfolio/security/code-scanning/44)

To fix the missing rate limiting vulnerability, the rate-limiting middleware (`adminLimiter`) should be applied before any authentication or database operations on the `.put` route for `/:contactId`. Move `adminLimiter` to be the first middleware for the route, just as rate-limiting comes first for the other routes. This ensures that requests are rate-limited before authentication handling or contact updating, minimizing denial-of-service risk. No new imports are needed, only change the middleware order on line 15.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
