### PR TITLE
Potential fix for code scanning alert no. 45: Missing rate limiting

### DIFF
--- a/server/routes/contacts.routes.js
+++ b/server/routes/contacts.routes.js
@@ -13,7 +13,7 @@ router.route('/')
 router.route('/:contactId')
   .get(readLimiter, authCtrl.requireSignin, authCtrl.requireAdmin, contactsCtrl.read)
   .put(adminLimiter, authCtrl.requireSignin, authCtrl.requireAdmin, contactsCtrl.update)
-  .delete(authCtrl.requireSignin, authCtrl.requireAdmin, deleteLimiter, contactsCtrl.remove)
+  .delete(deleteLimiter, authCtrl.requireSignin, authCtrl.requireAdmin, contactsCtrl.remove)
 
 router.param('contactId', contactsCtrl.contactByID)
 


### PR DESCRIPTION
Potential fix for [https://github.com/TheGuy3201/MyPortfolio/security/code-scanning/45](https://github.com/TheGuy3201/MyPortfolio/security/code-scanning/45)

To fix the issue, adjust the middleware order in the route definition. Specifically, on the `DELETE` route at line 16, move `deleteLimiter` so that it is the first middleware for that method. This ensures that all incoming `DELETE` requests for contacts are checked against the rate limiter _before_ any authentication or authorization logic, minimizing the risk that expensive DB checks or other backend logic (such as admin check) are executed unbounded. Only reorder the middleware within the route definition. No changes to logic or parameters are required; just rearrange the middleware so `deleteLimiter` is the first in the stack for the route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
