### PR TITLE
Potential fix for code scanning alert no. 46: Missing rate limiting

### DIFF
--- a/server/routes/educations.routes.js
+++ b/server/routes/educations.routes.js
@@ -7,12 +7,12 @@ const router = express.Router()
 
 router.route('/')
   .get(readLimiter, educationCtrl.list)
-  .post(authCtrl.requireSignin, authCtrl.requireAdmin, adminLimiter, educationCtrl.create)
+  .post(adminLimiter, authCtrl.requireSignin, authCtrl.requireAdmin, educationCtrl.create)
 
 router.route('/:educationId')
   .get(readLimiter, educationCtrl.read)
-  .put(authCtrl.requireSignin, authCtrl.requireAdmin, adminLimiter, educationCtrl.update)
-  .delete(authCtrl.requireSignin, authCtrl.requireAdmin, deleteLimiter, educationCtrl.remove)
+  .put(adminLimiter, authCtrl.requireSignin, authCtrl.requireAdmin, educationCtrl.update)
+  .delete(deleteLimiter, authCtrl.requireSignin, authCtrl.requireAdmin, educationCtrl.remove)
 
 router.param('educationId', educationCtrl.educationByID)
 


### PR DESCRIPTION
Potential fix for [https://github.com/TheGuy3201/MyPortfolio/security/code-scanning/46](https://github.com/TheGuy3201/MyPortfolio/security/code-scanning/46)

The best way to fix this is to ensure that rate-limiting occurs **before any middleware that may perform database operations** — including within authentication and admin-check middleware. In this case, we should move (or add) the appropriate rate limiting middleware (`adminLimiter`) **before** `authCtrl.requireSignin` and `authCtrl.requireAdmin` on all relevant routes.  
- For the POST `/` route, change the middleware order to: `.post(adminLimiter, authCtrl.requireSignin, authCtrl.requireAdmin, educationCtrl.create)`
- Similarly, for `PUT` and `DELETE`, ensure rate limiting precedes all authentication/authorization middleware.
- DO NOT remove rate-limiting from the controller calls; instead, move it up in the middleware chain.

No new methods or imports are required, as the middleware is already imported and available.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
