### PR TITLE
Potential fix for code scanning alert no. 49: Missing rate limiting

### DIFF
--- a/server/routes/projects.routes.js
+++ b/server/routes/projects.routes.js
@@ -6,7 +6,7 @@ import { readLimiter, adminLimiter, deleteLimiter } from '../middleware/rateLimi
 const router = express.Router();
 
 router.route('/')
-  .post(authCtrl.requireSignin, authCtrl.requireAdmin, adminLimiter, projectCtrl.create)
+  .post(adminLimiter, authCtrl.requireSignin, authCtrl.requireAdmin, projectCtrl.create)
   .get(readLimiter, projectCtrl.list);
 
 router.route('/:projectId')


### PR DESCRIPTION
Potential fix for [https://github.com/TheGuy3201/MyPortfolio/security/code-scanning/49](https://github.com/TheGuy3201/MyPortfolio/security/code-scanning/49)

To fix the problem, the route handler stack for the `POST /` route should apply a *generic* rate-limiting middleware **before** any authentication or authorization middleware. This will ensure incoming requests are rate-limited before any expensive operations (such as database queries in `authCtrl.requireSignin` or `requireAdmin`).  
- In `server/routes/projects.routes.js`, apply the desired rate limiter (likely `adminLimiter` given the operation is admin-only; if a generic limiter exists, use that) as the **first middleware** for the POST route on `/`.
- This may mean moving `adminLimiter` to the first position, or if you want to differentiate, creating a new generic limiter for authentication/authorization routes.
- Also, ensure the import for the rate limiter (`adminLimiter`) remains.
- Only the lines for the route handler stack (POST `/`) need to be changed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
