### PR TITLE
Potential fix for code scanning alert no. 56: Missing rate limiting

### DIFF
--- a/server/routes/users.routes.js
+++ b/server/routes/users.routes.js
@@ -15,6 +15,6 @@ router.route('/:userId')
   .put(authCtrl.requireSignin, authCtrl.hasAuthorization, writeLimiter, validateUserInput, userCtrl.update)
   .delete(authCtrl.requireSignin, authCtrl.hasAuthorization, deleteLimiter, userCtrl.remove)
 
-router.param('userId', userCtrl.userByID)
+router.param('userId', readLimiter, userCtrl.userByID)
 
 export default router


### PR DESCRIPTION
Potential fix for [https://github.com/TheGuy3201/MyPortfolio/security/code-scanning/56](https://github.com/TheGuy3201/MyPortfolio/security/code-scanning/56)

To fix the problem, we need to apply a suitable rate limiter middleware to the param route associated with `userId`, so that requests causing this param middleware to trigger (and thus a database access) are rate limited. In Express, you can pass middleware as the second argument to `router.param()`, so we should wrap userCtrl.userByID with a rate limiter. Given defined limiters in the imports (on line 4), the most appropriate is likely `readLimiter`, since the param is used for reading user info before getting/putting/deleting, and it matches the usage style of `readLimiter` in current routes (such as GET and param-requiring routes). We achieve this by passing the limiter middleware (e.g. `readLimiter`) before `userCtrl.userByID` in the `router.param` registration.

No additional methods or definitions are needed, and the required `readLimiter` is already imported. Only change line 18 of server/routes/users.routes.js to apply `readLimiter` to the param middleware.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
