### PR TITLE
Potential fix for code scanning alert no. 55: Missing rate limiting

### DIFF
--- a/server/routes/services.routes.js
+++ b/server/routes/services.routes.js
@@ -15,7 +15,7 @@ router.route('/all')
 router.route('/:serviceId')
   .get(readLimiter, servicesCtrl.read)
   .put(authCtrl.requireSignin, authCtrl.requireAdmin, adminLimiter, servicesCtrl.update)
-  .delete(authCtrl.requireSignin, authCtrl.requireAdmin, deleteLimiter, servicesCtrl.remove)
+  .delete(deleteLimiter, authCtrl.requireSignin, authCtrl.requireAdmin, servicesCtrl.remove)
 
 router.param('serviceId', servicesCtrl.serviceByID)
 


### PR DESCRIPTION
Potential fix for [https://github.com/TheGuy3201/MyPortfolio/security/code-scanning/55](https://github.com/TheGuy3201/MyPortfolio/security/code-scanning/55)

The correct fix is to reorder the middleware chain for the DELETE route defined on line 18. Specifically, move the `deleteLimiter` middleware so that it comes *before* `authCtrl.requireSignin` and `authCtrl.requireAdmin`. This ensures that high volume requests are blocked by the rate limiter before any expensive authentication or authorization routines that may require database access. No new methods or definitions are needed, just a change in ordering of middleware for this route. No other routes need to be modified unless similar issues exist in their middleware chains.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
