### PR TITLE
Potential fix for code scanning alert no. 59: Missing rate limiting

### DIFF
--- a/server/routes/services.routes.js
+++ b/server/routes/services.routes.js
@@ -14,7 +14,7 @@ router.route('/all')
 
 router.route('/:serviceId')
   .get(readLimiter, servicesCtrl.read)
-  .put(authCtrl.requireSignin, authCtrl.requireAdmin, adminLimiter, servicesCtrl.update)
+  .put(adminLimiter, authCtrl.requireSignin, authCtrl.requireAdmin, servicesCtrl.update)
   .delete(deleteLimiter, authCtrl.requireSignin, authCtrl.requireAdmin, servicesCtrl.remove)
 
 router.param('serviceId', servicesCtrl.serviceByID)


### PR DESCRIPTION
Potential fix for [https://github.com/TheGuy3201/MyPortfolio/security/code-scanning/59](https://github.com/TheGuy3201/MyPortfolio/security/code-scanning/59)

To fix this problem, move the rate limiting middleware (`adminLimiter`) *before* the `authCtrl.requireSignin` and `authCtrl.requireAdmin` middlewares in the handler chain for the affected route. This ensures that before any expensive operation (such as DB access in authentication or authorization checks), the request is first rate-limited. Only requests that pass the rate limit will proceed to the authentication and then to the update logic, better protecting against denial-of-service. Only the middleware ordering on line 17 in `server/routes/services.routes.js` needs to be updated.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
